### PR TITLE
Potential fix for code scanning alert no. 14: Pointer overflow check

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
-# x11libre-65kmaxres Security Policy
+# X11Libre Security Policy
 
 ##  Reporting Vulnerabilities
 
-We take security seriously in x11libre. If you discover any vulnerabilities, please report them responsibly.
+We take security seriously in X11Libre. If you discover any vulnerabilities, please report them responsibly.
 
 - **Contact**: legendarydood@gmail.com 
 - **Preferred Method**: Email with detailed reproduction steps, logs, and system info 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# x11libre-65kmaxres Security Policy
+
+##  Reporting Vulnerabilities
+
+We take security seriously in x11libre. If you discover any vulnerabilities, please report them responsibly.
+
+- **Contact**: legendarydood@gmail.com 
+- **Preferred Method**: Email with detailed reproduction steps, logs, and system info 
+- **Public Disclosure**: Please wait until we’ve resolved the issue before making it public 
+
+##  Supported Versions
+
+| Version         | Status                    |
+| --------------- | ------------------------- |
+| `main` branch   |  Supported and maintained |
+| Older tags      |  No longer supported      |
+
+We recommend always using the latest release for performance and security fixes.
+
+##  Security Best Practices (User-Side)
+
+To help protect your systems when using x11libre:
+
+- Use minimal privileges when running X sessions 
+- Avoid setuid binaries unless required 
+- Keep your display manager and window manager updated 
+- Regularly audit any X11-forwarded connections, especially over SSH 
+- Use sandboxing or containerization when integrating third-party extensions
+
+##  Developer Guidelines
+
+For contributors submitting PRs:
+
+- Don’t introduce new system calls without justification 
+- Avoid unsafe memory operations (especially in C/C++) 
+- Use compile-time and runtime hardening flags 
+- Submit fuzzing harnesses or test vectors for complex parsing logic 
+
+---
+
+We appreciate your help in keeping x11libre safe for everyone. Let’s build something resilient, secure, and libre.

--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1739,7 +1739,7 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
     pmap->numPixelsBlue[client] += npixB;
     pmap->freeBlue -= npixB;
 
-    for (pDst = pixels; pDst < pixels + c; pDst++)
+    for (pDst = pixels; (pDst - pixels) < c; pDst++)
         *pDst |= ALPHAMASK(pmap->pVisual);
 
     free(ppixBlue);


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/14](https://github.com/HaplessIdiot/xserver/security/code-scanning/14)

To fix the issue, we need to avoid performing pointer arithmetic that could result in undefined behavior. Instead of comparing `pDst` with `pixels + c`, we should calculate the difference between `pDst` and `pixels` and compare it with `c`. This approach avoids creating a potentially invalid pointer and ensures the comparison is safe.

Specifically:
1. Replace `pDst < pixels + c` with `(pDst - pixels) < c`. This ensures that the comparison is performed using integer arithmetic, which is well-defined.
2. Ensure that `pDst` and `pixels` are valid pointers and that `c` is non-negative.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
