### PR TITLE
Potential fix for code scanning alert no. 14: Pointer overflow check

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1739,7 +1739,7 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
     pmap->numPixelsBlue[client] += npixB;
     pmap->freeBlue -= npixB;
 
-    for (pDst = pixels; pDst < pixels + c; pDst++)
+    for (pDst = pixels; (pDst - pixels) < c; pDst++)
         *pDst |= ALPHAMASK(pmap->pVisual);
 
     free(ppixBlue);


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/14](https://github.com/HaplessIdiot/xserver/security/code-scanning/14)

To fix the issue, we need to avoid performing pointer arithmetic that could result in undefined behavior. Instead of comparing `pDst` with `pixels + c`, we should calculate the difference between `pDst` and `pixels` and compare it with `c`. This approach avoids creating a potentially invalid pointer and ensures the comparison is safe.

Specifically:
1. Replace `pDst < pixels + c` with `(pDst - pixels) < c`. This ensures that the comparison is performed using integer arithmetic, which is well-defined.
2. Ensure that `pDst` and `pixels` are valid pointers and that `c` is non-negative.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
