### PR TITLE
Potential fix for code scanning alert no. 12: Pointer overflow check

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1713,27 +1713,27 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
     *pbmask <<= pmap->pVisual->offsetBlue;
 
     ppix = rpix + pmap->numPixelsRed[client];
-    for (pDst = pixels, p = ppixRed; p < ppixRed + npixR; p++) {
+    for (pDst = pixels, p = ppixRed; (size_t)(p - ppixRed) < npixR; p++) {
         *ppix++ = *p;
-        if (p < ppixRed + c)
+        if ((size_t)(p - ppixRed) < c)
             *pDst++ |= *p << pmap->pVisual->offsetRed;
     }
     pmap->numPixelsRed[client] += npixR;
     pmap->freeRed -= npixR;
 
     ppix = gpix + pmap->numPixelsGreen[client];
-    for (pDst = pixels, p = ppixGreen; p < ppixGreen + npixG; p++) {
+    for (pDst = pixels, p = ppixGreen; (size_t)(p - ppixGreen) < npixG; p++) {
         *ppix++ = *p;
-        if (p < ppixGreen + c)
+        if ((size_t)(p - ppixGreen) < c)
             *pDst++ |= *p << pmap->pVisual->offsetGreen;
     }
     pmap->numPixelsGreen[client] += npixG;
     pmap->freeGreen -= npixG;
 
     ppix = bpix + pmap->numPixelsBlue[client];
-    for (pDst = pixels, p = ppixBlue; p < ppixBlue + npixB; p++) {
+    for (pDst = pixels, p = ppixBlue; (size_t)(p - ppixBlue) < npixB; p++) {
         *ppix++ = *p;
-        if (p < ppixBlue + c)
+        if ((size_t)(p - ppixBlue) < c)
             *pDst++ |= *p << pmap->pVisual->offsetBlue;
     }
     pmap->numPixelsBlue[client] += npixB;


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/12](https://github.com/HaplessIdiot/xserver/security/code-scanning/12)

To fix the issue, we need to replace the pointer-based range check `p < ppixBlue + npixB` with an integer-based range check. This involves calculating the difference between the pointers `ppixBlue` and `p` and comparing it to `npixB`. This ensures that the comparison is performed using integers, avoiding undefined behavior associated with pointer overflow.

Steps to implement the fix:
1. Replace the condition `p < ppixBlue + npixB` with `(size_t)(p - ppixBlue) < npixB`.
2. Ensure that `npixB` is treated as an unsigned integer to prevent issues with signed comparisons.
3. Apply similar fixes to other range checks in the code snippet, such as `p < ppixGreen + npixG` and `p < ppixRed + npixR`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
