### PR TITLE
Potential fix for code scanning alert no. 7: Pointer overflow check

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1657,7 +1657,7 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
         return BadAlloc;
 
     /* start out with empty pixels */
-    for (p = pixels; p < pixels + c; p++)
+    for (p = pixels; (p - pixels) < c; p++)
         *p = 0;
 
     ppixRed = calloc(npixR, sizeof(Pixel));


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/7](https://github.com/HaplessIdiot/xserver/security/code-scanning/7)

To fix the issue, replace the pointer-based range check `p < pixels + c` with an integer-based range check. This avoids undefined behavior by ensuring that the comparison is performed using integer arithmetic rather than pointer arithmetic. Specifically, calculate the difference between `p` and `pixels` as an integer and compare it to `c`. This ensures that the range check is safe and portable.

Changes required:
1. Replace `p < pixels + c` with `(p - pixels) < c`.
2. Ensure that `p` and `pixels` are valid pointers before performing the subtraction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
