### PR TITLE
Potential fix for code scanning alert no. 4: Pointer overflow check

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1771,7 +1771,7 @@ AllocPseudo(int client, ColormapPtr pmap, int c, int r, Bool contig,
         ppix = reallocarray(pmap->clientPixelsRed[client],
                             pmap->numPixelsRed[client] + npix, sizeof(Pixel));
         if (!ppix) {
-            for (p = ppixTemp; p < ppixTemp + npix; p++)
+            for (p = ppixTemp; (p - ppixTemp) < npix; p++)
                 pmap->red[*p].refcnt = 0;
             free(ppixTemp);
             return BadAlloc;


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/4](https://github.com/HaplessIdiot/xserver/security/code-scanning/4)

To fix the issue, we need to avoid performing pointer arithmetic that could result in undefined behavior. Instead of comparing pointers directly, we should calculate the difference between the pointers as integers and compare that to `npix`. This ensures that the comparison is performed safely using integer arithmetic, which does not have the same undefined behavior as pointer arithmetic.

Specifically, we will replace the condition `p < ppixTemp + npix` with a condition that calculates the difference between `p` and `ppixTemp` as an integer and compares it to `npix`. This approach avoids the risk of pointer overflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
