### PR TITLE
Potential fix for code scanning alert no. 6: Pointer overflow check

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1782,7 +1782,7 @@ AllocPseudo(int client, ColormapPtr pmap, int c, int r, Bool contig,
         pDst = pixels;
         for (p = ppixTemp; p < ppixTemp + npix; p++) {
             *ppix++ = *p;
-            if (p < ppixTemp + c)
+            if ((p - ppixTemp) < c)
                 *pDst++ = *p;
         }
         pmap->numPixelsRed[client] += npix;


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/6](https://github.com/HaplessIdiot/xserver/security/code-scanning/6)

To fix the issue, we need to avoid relying on pointer arithmetic for range checks. Instead, we should compare the index `c` directly against the allocated size of `ppixTemp`. This ensures that the range check is performed using integer arithmetic, which is well-defined and avoids undefined behavior.

The best way to fix the problem is to replace the comparison `p < ppixTemp + c` with a comparison based on the index `p - ppixTemp` and the allocated size `c`. Specifically, we can write `(p - ppixTemp) < c`, which checks whether the current pointer `p` is within the allocated range of `ppixTemp`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
