### PR TITLE
Potential fix for code scanning alert no. 5: Pointer overflow check

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1780,9 +1780,9 @@ AllocPseudo(int client, ColormapPtr pmap, int c, int r, Bool contig,
         ppix += pmap->numPixelsRed[client];
         *pppixFirst = ppix;
         pDst = pixels;
-        for (p = ppixTemp; p < ppixTemp + npix; p++) {
+        for (p = ppixTemp; (p - ppixTemp) < npix; p++) {
             *ppix++ = *p;
-            if (p < ppixTemp + c)
+            if ((p - ppixTemp) < c)
                 *pDst++ = *p;
         }
         pmap->numPixelsRed[client] += npix;


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/5](https://github.com/HaplessIdiot/xserver/security/code-scanning/5)

To fix the issue, the comparison `p < ppixTemp + npix` should be rewritten to avoid relying on pointer arithmetic that could result in undefined behavior. Instead, the range check should be performed using integer arithmetic. Specifically, the difference between the pointers can be calculated and compared to `npix`. This ensures that the comparison is safe and avoids undefined behavior.

The fix involves:
1. Replacing `p < ppixTemp + npix` with `(p - ppixTemp) < npix`, which uses integer subtraction to calculate the offset of `p` relative to `ppixTemp` and compares it to `npix`.
2. This change ensures that the comparison is performed using integers rather than relying on potentially unsafe pointer arithmetic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
