### PR TITLE
Update loader.c to add ABI Mismatch Warning for NVIDIA Driver

### DIFF
--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -157,7 +157,14 @@ LoaderSetOptions(unsigned long opts)
 Bool
 LoaderShouldIgnoreABI(void)
 {
-    return (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL) != 0;
+    LogMessage(X_WARNING,
+               "ABI mismatch detected possibly from an NVIDIA driver. Attempting to continue loading X...\n"
+               "Expected ABI versions: ANSIC=%d, VideoDriver=%d, XInput=%d, Extension=%d\n",
+               LoaderVersionInfo.ansicVersion,
+               LoaderVersionInfo.videodrvVersion,
+               LoaderVersionInfo.xinputVersion,
+               LoaderVersionInfo.extensionVersion);
+    return TRUE;
 }
 
 int


### PR DESCRIPTION
This change makes the -IgnoreABI flag assumed TRUE and adds a new warning in logs to show ABI mismatch. This would seriously help streamline the process for NVIDIA users. Most are having ABI troubles and could possibly load a login screen rather than kicking them to terminal without a clue.