### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -1,5 +1,8 @@
 name: Build X servers
 
+permissions:
+    contents: read
+
 env:
     MESON_BUILDDIR:  "build"
     X11_PREFIX:      /home/runner/x11


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/16](https://github.com/HaplessIdiot/xserver/security/code-scanning/16)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow does not appear to perform any actions requiring write permissions, we will set the permissions to `contents: read` at the workflow level. This will apply the minimal required permissions to all jobs in the workflow. If any job requires additional permissions, they can be specified at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
