### PR TITLE
Potential fix for code scanning alert no. 2577: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: lint
 
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   clang-tidy:
     name: clang-tidy


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/2577](https://github.com/HaplessIdiot/xserver/security/code-scanning/2577)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow is performing linting operations, it likely only requires read access to the repository contents. We will add the `permissions` key at the root level of the workflow to apply the permissions to all jobs in the workflow. The permissions will be set to `contents: read`, which is the minimal privilege required for this task.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
