### PR TITLE
Potential fix for code scanning alert no. 2582: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -1,6 +1,10 @@
 # .github/workflows/flawfinder-analysis.yml
 name: Flawfinder Code Scanning
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/2582](https://github.com/HaplessIdiot/xserver/security/code-scanning/2582)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Based on the workflow's functionality, the minimal permissions required are `contents: read` for accessing repository contents and `security-events: write` for uploading SARIF files.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow file.
2. Specifying `contents: read` and `security-events: write` as the required permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
