### PR TITLE
Potential fix for code scanning alert no. 2583: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -1,5 +1,9 @@
 name: Run Flawfinder
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/2583](https://github.com/HaplessIdiot/xserver/security/code-scanning/2583)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: read` is needed to allow the workflow to read the repository's contents.
- `actions: write` is required for the `actions/upload-artifact` step to upload the generated reports.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
