### PR TITLE
Potential fix for code scanning alert no. 2629: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -1,5 +1,8 @@
 name: Build X servers
 
+permissions:
+    contents: read
+
 env:
     MESON_BUILDDIR:  "build"
     X11_PREFIX:      /home/runner/x11


### PR DESCRIPTION
Potential fix for [https://github.com/HaplessIdiot/xserver/security/code-scanning/2629](https://github.com/HaplessIdiot/xserver/security/code-scanning/2629)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the workflow's actions, such as checking out code and caching dependencies, the `contents: read` permission is sufficient. If any specific steps require additional permissions (e.g., `pull-requests: write`), they can be added as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
